### PR TITLE
Fixed bug in flax_util.py using outdated flax api

### DIFF
--- a/qwix/_src/flax_util.py
+++ b/qwix/_src/flax_util.py
@@ -369,7 +369,7 @@ def update_boxed(
       axes = update_sharding(
           axes, shape=shape, split=split, merge=merge, transpose=transpose
       )
-      boxed.set_metadata('sharding_names', axes)
+      boxed.set_metadata(sharding_names=axes)
   elif isinstance(boxed, jax.Array):  # not boxed.
     if value is not None:
       boxed = value


### PR DESCRIPTION
Where I was getting the following reasoning tace:
/usr/local/lib/python3.12/dist-packages/qwix/_src/flax_util.py in update_boxed(boxed, value, split, merge, transpose)
    347           axes, shape=shape, split=split, merge=merge, transpose=transpose
    348       )
--> 349       boxed.set_metadata('sharding_names', axes)
    350   elif isinstance(boxed, jax.Array):  # not boxed.
    351     if value is not None:

/usr/local/lib/python3.12/dist-packages/flax/nnx/variablelib.py in set_metadata(self, *args, **kwargs)
    390       self._var_metadata.update(kwargs)
    391     else:
--> 392       raise TypeError(
    393         f'set_metadata takes either 1 argument or 1 or more keyword arguments, got args={args}, kwargs={kwargs}'
    394       )

TypeError: set_metadata takes either 1 argument or 1 or more keyword arguments, got args=('sharding_names', ('tp', 'fsdp', None)), kwargs={}

Bug originates from this notebook I've been working on with tunix:
https://colab.research.google.com/drive/1eQHFYhRlK8y6Q_F_s4QaDmVMA6NlYDJC#scrollTo=RTlz7JP7yCpT
